### PR TITLE
Support caching for map primitive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.3.2
 	github.com/google/uuid v1.1.1
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/stretchr/testify v1.4.0
 	google.golang.org/grpc v1.27.0
 )

--- a/go.sum
+++ b/go.sum
@@ -174,6 +174,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.1.0/go.mod h1:f5nM7jw/oeRSadq3xC
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -380,8 +380,8 @@ func (d *Database) GetLog(ctx context.Context, name string) (log.Log, error) {
 }
 
 // GetMap gets or creates a Map with the given name
-func (d *Database) GetMap(ctx context.Context, name string) (_map.Map, error) {
-	return _map.New(ctx, primitive.NewName(d.Namespace, d.Name, d.scope, name), d.sessions)
+func (d *Database) GetMap(ctx context.Context, name string, opts ..._map.Option) (_map.Map, error) {
+	return _map.New(ctx, primitive.NewName(d.Namespace, d.Name, d.scope, name), d.sessions, opts...)
 }
 
 // GetSet gets or creates a Set with the given name
@@ -442,8 +442,8 @@ func (g *PartitionGroup) GetLog(ctx context.Context, name string) (log.Log, erro
 }
 
 // GetMap gets or creates a Map with the given name
-func (g *PartitionGroup) GetMap(ctx context.Context, name string) (_map.Map, error) {
-	return _map.New(ctx, primitive.NewName(g.Namespace, g.Name, g.scope, name), g.sessions)
+func (g *PartitionGroup) GetMap(ctx context.Context, name string, opts ..._map.Option) (_map.Map, error) {
+	return _map.New(ctx, primitive.NewName(g.Namespace, g.Name, g.scope, name), g.sessions, opts...)
 }
 
 // GetSet gets or creates a Set with the given name

--- a/pkg/client/map/cache.go
+++ b/pkg/client/map/cache.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package _map
+package _map //nolint:golint
 
 import (
 	"context"

--- a/pkg/client/map/cache.go
+++ b/pkg/client/map/cache.go
@@ -1,0 +1,240 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _map
+
+import (
+	"context"
+	"errors"
+	"github.com/hashicorp/golang-lru"
+	"sync"
+)
+
+// newCachingMap returns a decorated map that caches updates to the given map
+func newCachingMap(_map Map, size int) (Map, error) {
+	cache, err := lru.New(size)
+	if err != nil {
+		return nil, err
+	}
+	cachingMap := &cachingMap{
+		delegatingMap: newDelegatingMap(_map),
+		cache:         cache,
+		state: &cacheState{
+			waiters: make(map[int64]*sync.Cond),
+			mu:      &sync.RWMutex{},
+		},
+	}
+	if err := cachingMap.open(); err != nil {
+		return nil, err
+	}
+	return cachingMap, nil
+}
+
+// cachingMap is an implementation of the Map interface that caches entries
+type cachingMap struct {
+	*delegatingMap
+	cancel context.CancelFunc
+	cache  *lru.Cache
+	state  *cacheState
+}
+
+// open opens the map listeners
+func (m *cachingMap) open() error {
+	ch := make(chan *Event)
+	ctx, cancel := context.WithCancel(context.Background())
+	m.state.Lock()
+	m.cancel = cancel
+	m.state.Unlock()
+	if err := m.delegatingMap.Watch(ctx, ch, WithReplay()); err != nil {
+		return err
+	}
+	go func() {
+		for event := range ch {
+			switch event.Type {
+			case EventNone:
+				m.cache.Add(event.Entry.Key, event.Entry)
+			case EventInserted:
+				m.cache.Add(event.Entry.Key, event.Entry)
+			case EventUpdated:
+				m.cache.Add(event.Entry.Key, event.Entry)
+			case EventRemoved:
+				m.cache.Remove(event.Entry.Key)
+			}
+
+			// Wake up goroutines waiting for this update
+			m.state.setMaxUpdated(event.Entry.Version)
+		}
+	}()
+	return nil
+}
+
+func (m *cachingMap) Put(ctx context.Context, key string, value []byte, opts ...PutOption) (*Entry, error) {
+	// Put the entry in the map using the underlying map delegate
+	entry, err := m.delegatingMap.Put(ctx, key, value, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the update is successful, record the max seen version
+	m.state.setMaxSeen(entry.Version)
+	return entry, nil
+}
+
+func (m *cachingMap) Remove(ctx context.Context, key string, opts ...RemoveOption) (*Entry, error) {
+	// Remove the entry from the map using the underlying map delegate
+	entry, err := m.delegatingMap.Remove(ctx, key, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the update is successful, update the max seen version for read-your-writes consistency
+	if entry != nil {
+		m.state.setMaxSeen(entry.Version)
+	}
+	return entry, nil
+}
+
+func (m *cachingMap) Get(ctx context.Context, key string, opts ...GetOption) (*Entry, error) {
+	// Get the current cache state
+	m.state.RLock()
+	closed := m.state.closed
+	current := m.state.isCurrent()
+	m.state.RUnlock()
+
+	// If the cache is closed, return an error
+	if closed {
+		return nil, errors.New("cache closed")
+	}
+
+	// If the client write a value at a later point than the current cache point, wait for updates
+	// to be propagated to the cache
+	if !current {
+		// Acquire a write lock again (double checked lock)
+		m.state.Lock()
+
+		// Check whether the cache is closed again
+		if m.state.closed {
+			return nil, errors.New("cache closed")
+		}
+
+		// Check the current cache point again before creating a condition
+		if !m.state.isCurrent() {
+			m.state.awaitUpdate()
+		}
+
+		// Check that the cache is not closed once more - it could have been closed during a awaitUpdate() call
+		if m.state.closed {
+			return nil, errors.New("cache closed")
+		}
+
+		// Release the write lock
+		m.state.Unlock()
+	}
+
+	// If the entry is present in the cache, return it
+	if entry, ok := m.cache.Get(key); ok {
+		return entry.(*Entry), nil
+	}
+
+	// Otherwise, fetch the entry from the underlying map and cache it
+	entry, err := m.delegatingMap.Get(ctx, key, opts...)
+	if err != nil {
+		return nil, err
+	}
+	m.cache.Add(key, entry)
+	return entry, nil
+}
+
+func (m *cachingMap) Close(ctx context.Context) error {
+	m.state.Lock()
+	if m.cancel != nil {
+		m.cancel()
+	}
+	m.state.closed = true
+	m.state.Unlock()
+	return m.delegatingMap.Close(ctx)
+}
+
+// cacheState contains the state of the cache
+type cacheState struct {
+	maxSeen     int64
+	maxUpdated  int64
+	maxComplete int64
+	waiters     map[int64]*sync.Cond
+	mu          *sync.RWMutex
+	closed      bool
+}
+
+// Lock locks the cache state
+func (s *cacheState) Lock() {
+	s.mu.Lock()
+}
+
+// Unlock unlocks the cache state
+func (s *cacheState) Unlock() {
+	s.mu.Unlock()
+}
+
+// RLock read locks the cache state
+func (s *cacheState) RLock() {
+	s.mu.RLock()
+}
+
+// rUnlock read unlocks the cache state
+func (s *cacheState) RUnlock() {
+	s.mu.RUnlock()
+}
+
+// setMaxSeen sets the max seen version
+func (s *cacheState) setMaxSeen(seenVersion int64) {
+	s.mu.Lock()
+	if seenVersion > s.maxSeen {
+		s.maxSeen = seenVersion
+	}
+	s.mu.Unlock()
+}
+
+// setMaxUpdated sets the max updated version and awakens waiters waiting for the update
+func (s *cacheState) setMaxUpdated(updateVersion int64) {
+	s.mu.Lock()
+	if updateVersion > s.maxUpdated {
+		s.maxUpdated = updateVersion
+		for version := s.maxComplete; version <= updateVersion; version++ {
+			waiter, ok := s.waiters[version]
+			if ok {
+				waiter.Broadcast()
+			}
+			s.maxComplete = version
+		}
+	}
+	s.mu.Unlock()
+}
+
+// awaitUpdate waits for the cache state to be propagated
+func (s *cacheState) awaitUpdate() {
+	maxSeen := s.maxSeen
+	waiter, ok := s.waiters[maxSeen]
+	if !ok {
+		waiter = sync.NewCond(s.mu)
+		s.waiters[maxSeen] = waiter
+	}
+	for s.closed || maxSeen <= s.maxUpdated {
+		waiter.Wait()
+	}
+}
+
+// isCurrent returns a boolean indicating whether the cache is current
+func (s *cacheState) isCurrent() bool {
+	return s.maxSeen <= s.maxUpdated
+}

--- a/pkg/client/map/cache_test.go
+++ b/pkg/client/map/cache_test.go
@@ -1,0 +1,226 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _map //nolint:golint
+
+import (
+	"context"
+	"github.com/atomix/go-client/pkg/client/primitive"
+	"github.com/atomix/go-client/pkg/client/test"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCachedMapOperations(t *testing.T) {
+	partitions, closers := test.StartTestPartitions(3)
+	defer test.StopTestPartitions(closers)
+
+	sessions, err := test.OpenSessions(partitions)
+	assert.NoError(t, err)
+	defer test.CloseSessions(sessions)
+
+	name := primitive.NewName("default", "test", "default", "test")
+	_map, err := New(context.TODO(), name, sessions, WithCache(1))
+	assert.NoError(t, err)
+
+	kv, err := _map.Get(context.Background(), "foo")
+	assert.NoError(t, err)
+	assert.Nil(t, kv)
+
+	size, err := _map.Len(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, size)
+
+	kv, err = _map.Put(context.Background(), "foo", []byte("bar"))
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "bar", string(kv.Value))
+
+	kv, err = _map.Get(context.Background(), "foo")
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "foo", kv.Key)
+	assert.Equal(t, "bar", string(kv.Value))
+	version := kv.Version
+
+	size, err = _map.Len(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, size)
+
+	kv, err = _map.Remove(context.Background(), "foo")
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "foo", kv.Key)
+	assert.Equal(t, "bar", string(kv.Value))
+	assert.Equal(t, version, kv.Version)
+
+	size, err = _map.Len(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, size)
+
+	kv, err = _map.Put(context.Background(), "foo", []byte("bar"))
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "bar", string(kv.Value))
+
+	kv, err = _map.Put(context.Background(), "bar", []byte("baz"))
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "baz", string(kv.Value))
+
+	kv, err = _map.Put(context.Background(), "foo", []byte("baz"))
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "baz", string(kv.Value))
+
+	err = _map.Clear(context.Background())
+	assert.NoError(t, err)
+
+	size, err = _map.Len(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, size)
+
+	kv, err = _map.Put(context.Background(), "foo", []byte("bar"))
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	kv1, err := _map.Get(context.Background(), "foo")
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	_, err = _map.Put(context.Background(), "foo", []byte("baz"), IfVersion(1))
+	assert.Error(t, err)
+
+	kv2, err := _map.Put(context.Background(), "foo", []byte("baz"), IfVersion(kv1.Version))
+	assert.NoError(t, err)
+	assert.NotEqual(t, kv1.Version, kv2.Version)
+	assert.Equal(t, "baz", string(kv2.Value))
+
+	_, err = _map.Remove(context.Background(), "foo", IfVersion(1))
+	assert.Error(t, err)
+
+	removed, err := _map.Remove(context.Background(), "foo", IfVersion(kv2.Version))
+	assert.NoError(t, err)
+	assert.NotNil(t, removed)
+	assert.Equal(t, kv2.Version, removed.Version)
+}
+
+func TestCachedMapStreams(t *testing.T) {
+	partitions, closers := test.StartTestPartitions(3)
+	defer test.StopTestPartitions(closers)
+
+	sessions, err := test.OpenSessions(partitions)
+	assert.NoError(t, err)
+	defer test.CloseSessions(sessions)
+
+	name := primitive.NewName("default", "test", "default", "test")
+	_map, err := New(context.TODO(), name, sessions, WithCache(1))
+	assert.NoError(t, err)
+
+	kv, err := _map.Put(context.Background(), "foo", []byte{1})
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	c := make(chan *Event)
+	latch := make(chan struct{})
+	go func() {
+		e := <-c
+		assert.Equal(t, "foo", e.Entry.Key)
+		assert.Equal(t, byte(2), e.Entry.Value[0])
+		e = <-c
+		assert.Equal(t, "bar", e.Entry.Key)
+		assert.Equal(t, byte(3), e.Entry.Value[0])
+		e = <-c
+		assert.Equal(t, "baz", e.Entry.Key)
+		assert.Equal(t, byte(4), e.Entry.Value[0])
+		e = <-c
+		assert.Equal(t, "foo", e.Entry.Key)
+		assert.Equal(t, byte(5), e.Entry.Value[0])
+		latch <- struct{}{}
+	}()
+
+	err = _map.Watch(context.Background(), c)
+	assert.NoError(t, err)
+
+	keyCh := make(chan *Event)
+	err = _map.Watch(context.Background(), keyCh, WithFilter(Filter{
+		Key: "foo",
+	}))
+	assert.NoError(t, err)
+
+	kv, err = _map.Put(context.Background(), "foo", []byte{2})
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "foo", kv.Key)
+	assert.Equal(t, byte(2), kv.Value[0])
+
+	event := <-keyCh
+	assert.NotNil(t, event)
+	assert.Equal(t, "foo", event.Entry.Key)
+	assert.Equal(t, kv.Version, event.Entry.Version)
+
+	kv, err = _map.Put(context.Background(), "bar", []byte{3})
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "bar", kv.Key)
+	assert.Equal(t, byte(3), kv.Value[0])
+
+	kv, err = _map.Put(context.Background(), "baz", []byte{4})
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "baz", kv.Key)
+	assert.Equal(t, byte(4), kv.Value[0])
+
+	kv, err = _map.Put(context.Background(), "foo", []byte{5})
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+	assert.Equal(t, "foo", kv.Key)
+	assert.Equal(t, byte(5), kv.Value[0])
+
+	event = <-keyCh
+	assert.NotNil(t, event)
+	assert.Equal(t, "foo", event.Entry.Key)
+	assert.Equal(t, kv.Version, event.Entry.Version)
+
+	<-latch
+
+	err = _map.Close(context.Background())
+	assert.NoError(t, err)
+
+	map1, err := New(context.TODO(), name, sessions, WithCache(1))
+	assert.NoError(t, err)
+
+	map2, err := New(context.TODO(), name, sessions, WithCache(1))
+	assert.NoError(t, err)
+
+	size, err := map1.Len(context.TODO())
+	assert.NoError(t, err)
+	assert.Equal(t, 3, size)
+
+	err = map1.Close(context.Background())
+	assert.NoError(t, err)
+
+	err = map1.Delete(context.Background())
+	assert.NoError(t, err)
+
+	err = map2.Delete(context.Background())
+	assert.NoError(t, err)
+
+	_map, err = New(context.TODO(), name, sessions, WithCache(1))
+	assert.NoError(t, err)
+
+	size, err = _map.Len(context.TODO())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, size)
+}

--- a/pkg/client/map/delegate.go
+++ b/pkg/client/map/delegate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package _map
+package _map //nolint:golint
 
 import (
 	"context"

--- a/pkg/client/map/delegate.go
+++ b/pkg/client/map/delegate.go
@@ -1,0 +1,72 @@
+// Copyright 2019-present Open Networking Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package _map
+
+import (
+	"context"
+	"github.com/atomix/go-client/pkg/client/primitive"
+)
+
+// newDelegatingMap returns a Map that delegates all method calls to the given Map
+func newDelegatingMap(_map Map) *delegatingMap {
+	return &delegatingMap{
+		delegate: _map,
+	}
+}
+
+// delegatingMap is a Map that delegates method calls to an underlying Map
+type delegatingMap struct {
+	delegate Map
+}
+
+func (m *delegatingMap) Name() primitive.Name {
+	return m.delegate.Name()
+}
+
+func (m *delegatingMap) Put(ctx context.Context, key string, value []byte, opts ...PutOption) (*Entry, error) {
+	return m.delegate.Put(ctx, key, value, opts...)
+}
+
+func (m *delegatingMap) Get(ctx context.Context, key string, opts ...GetOption) (*Entry, error) {
+	return m.delegate.Get(ctx, key, opts...)
+}
+
+func (m *delegatingMap) Remove(ctx context.Context, key string, opts ...RemoveOption) (*Entry, error) {
+	return m.delegate.Remove(ctx, key, opts...)
+}
+
+func (m *delegatingMap) Len(ctx context.Context) (int, error) {
+	return m.delegate.Len(ctx)
+}
+
+func (m *delegatingMap) Clear(ctx context.Context) error {
+	return m.delegate.Clear(ctx)
+}
+
+func (m *delegatingMap) Entries(ctx context.Context, ch chan<- *Entry) error {
+	return m.delegate.Entries(ctx, ch)
+}
+
+func (m *delegatingMap) Watch(ctx context.Context, ch chan<- *Event, opts ...WatchOption) error {
+	return m.delegate.Watch(ctx, ch, opts...)
+}
+
+func (m *delegatingMap) Close(ctx context.Context) error {
+	return m.delegate.Close(ctx)
+}
+
+func (m *delegatingMap) Delete(ctx context.Context) error {
+	return m.delegate.Delete(ctx)
+}

--- a/pkg/client/map/map.go
+++ b/pkg/client/map/map.go
@@ -29,7 +29,7 @@ const Type primitive.Type = "Map"
 // Client provides an API for creating Maps
 type Client interface {
 	// GetMap gets the Map instance of the given name
-	GetMap(ctx context.Context, name string) (Map, error)
+	GetMap(ctx context.Context, name string, opts ...Option) (Map, error)
 }
 
 // Map is a distributed set of keys and values
@@ -112,9 +112,9 @@ type Event struct {
 }
 
 // New creates a new partitioned Map
-func New(ctx context.Context, name primitive.Name, sessions []*primitive.Session) (Map, error) {
+func New(ctx context.Context, name primitive.Name, sessions []*primitive.Session, opts ...Option) (Map, error) {
 	results, err := util.ExecuteOrderedAsync(len(sessions), func(i int) (interface{}, error) {
-		return newPartition(ctx, name, sessions[i])
+		return newPartition(ctx, name, sessions[i], opts...)
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/client/map/options.go
+++ b/pkg/client/map/options.go
@@ -18,6 +18,39 @@ import (
 	api "github.com/atomix/api/proto/atomix/map"
 )
 
+// Option is an option for a Map instance
+type Option interface {
+	apply(options *options)
+}
+
+// options is a set of map options
+type options struct {
+	cached    bool
+	cacheSize int
+}
+
+// WithCache returns an option that enables caching for a Map
+func WithCache(size int) Option {
+	if size <= 0 {
+		panic("cache size must be positive")
+	}
+	return &cacheOption{
+		enabled: true,
+		size:    size,
+	}
+}
+
+// cacheOption is a cache enable option
+type cacheOption struct {
+	enabled bool
+	size    int
+}
+
+func (o *cacheOption) apply(options *options) {
+	options.cached = o.enabled
+	options.cacheSize = o.size
+}
+
 // PutOption is an option for the Put method
 type PutOption interface {
 	beforePut(request *api.PutRequest)

--- a/pkg/client/map/partition.go
+++ b/pkg/client/map/partition.go
@@ -23,15 +23,28 @@ import (
 	"google.golang.org/grpc"
 )
 
-func newPartition(ctx context.Context, name primitive.Name, session *primitive.Session) (Map, error) {
+func newPartition(ctx context.Context, name primitive.Name, session *primitive.Session, opts ...Option) (Map, error) {
+	options := &options{}
+	for _, opt := range opts {
+		opt.apply(options)
+	}
+
 	instance, err := primitive.NewInstance(ctx, name, session, &primitiveHandler{})
 	if err != nil {
 		return nil, err
 	}
-	return &mapPartition{
+	var partition Map = &mapPartition{
 		name:     name,
 		instance: instance,
-	}, nil
+	}
+	if options.cached {
+		cached, err := newCachingMap(partition, options.cacheSize)
+		if err != nil {
+			return nil, err
+		}
+		partition = cached
+	}
+	return partition, nil
 }
 
 type mapPartition struct {
@@ -122,7 +135,12 @@ func (m *mapPartition) Get(ctx context.Context, key string, opts ...GetOption) (
 			Updated: response.Updated,
 		}, nil
 	}
-	return nil, nil
+
+	// Return a non-empty nil-value Entry when response version is 0
+	return &Entry{
+		Key:     key,
+		Version: int64(response.Header.Index),
+	}, nil
 }
 
 func (m *mapPartition) Remove(ctx context.Context, key string, opts ...RemoveOption) (*Entry, error) {
@@ -259,23 +277,28 @@ func (m *mapPartition) Watch(ctx context.Context, ch chan<- *Event, opts ...Watc
 		defer close(ch)
 		for event := range stream {
 			response := event.(*api.EventResponse)
+			var version int64
 			var t EventType
 			switch response.Type {
 			case api.EventResponse_NONE:
 				t = EventNone
+				version = response.Version
 			case api.EventResponse_INSERTED:
 				t = EventInserted
+				version = response.Version
 			case api.EventResponse_UPDATED:
 				t = EventUpdated
+				version = response.Version
 			case api.EventResponse_REMOVED:
 				t = EventRemoved
+				version = int64(response.Header.Index)
 			}
 			ch <- &Event{
 				Type: t,
 				Entry: &Entry{
 					Key:     response.Key,
 					Value:   response.Value,
-					Version: response.Version,
+					Version: version,
 					Created: response.Created,
 					Updated: response.Updated,
 				},

--- a/pkg/client/map/partition.go
+++ b/pkg/client/map/partition.go
@@ -23,28 +23,15 @@ import (
 	"google.golang.org/grpc"
 )
 
-func newPartition(ctx context.Context, name primitive.Name, session *primitive.Session, opts ...Option) (Map, error) {
-	options := &options{}
-	for _, opt := range opts {
-		opt.apply(options)
-	}
-
+func newPartition(ctx context.Context, name primitive.Name, session *primitive.Session) (Map, error) {
 	instance, err := primitive.NewInstance(ctx, name, session, &primitiveHandler{})
 	if err != nil {
 		return nil, err
 	}
-	var partition Map = &mapPartition{
+	return &mapPartition{
 		name:     name,
 		instance: instance,
-	}
-	if options.cached {
-		cached, err := newCachingMap(partition, options.cacheSize)
-		if err != nil {
-			return nil, err
-		}
-		partition = cached
-	}
-	return partition, nil
+	}, nil
 }
 
 type mapPartition struct {


### PR DESCRIPTION
This PR adds support for wrapping a `Map` primitive in an LRU cache.

To cache a map, just use the `WithCache` option when constructing the map:
```go
m, err := client.GetMap(context.TODO(), "my-map", _map.WithCache(1000))
```

The cache is implemented using Hashicorp's LRU cache. When a client writes to the cache, any existing cached entries are deleted. A background goroutine listens for update events from the cluster to populate the cache. Because of the consistency guarantees of Atomix sessions, this guarantees a client will receive the same consistency guarantees as an uncached client.